### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-pre-production.yml
+++ b/.github/workflows/deploy-pre-production.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - name: Review API - Publish to Github Packages Registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               env:
                   GIT_ACCESS_TOKEN_CURL_CONFIG_KUCLAP_API_REVIEW: ${{ secrets.GIT_ACCESS_TOKEN_CURL_CONFIG_KUCLAP_API_REVIEW }}
                   ARG_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - name: Review API - Publish to Github Packages Registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               env:
                   GIT_ACCESS_TOKEN_CURL_CONFIG_KUCLAP_API_REVIEW: ${{ secrets.GIT_ACCESS_TOKEN_CURL_CONFIG_KUCLAP_API_REVIEW }}
                   ARG_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore